### PR TITLE
feat: add KubeStellar Console to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ may be out of scope for this repository.
 | [chart-vendor](https://github.com/vexxhost/chart-vendor) | Vendor Helm charts; |
 | [helmfile/chartify](https://github.com/helmfile/chartify) | Generate Helm charts from Kubernetes manifests/Kustomization; |
 | [Karmada](https://github.com/karmada-io/karmada) | Multi-Cloud, Multi-Cluster Kubernetes Orchestration; |
+| [KubeStellar Console](https://github.com/kubestellar/console) | AI-powered multi-cluster Kubernetes dashboard with real-time observability and 20+ CNCF integrations; CNCF Sandbox project; |
 | [Knative Serving](https://github.com/knative/serving) | Set of CRDs used to define serverless workloads; |
 | [koreo](https://github.com/koreo-dev/koreo-core) | Orchestrates multi-step processes that react to events and manage Kubernetes resources; |
 | [kro](https://github.com/kro-run/kro) | Define higher-level Kubernetes resources, composed of a multiple lower-level ones; |


### PR DESCRIPTION
## Summary

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the Other Tools section.

KubeStellar Console is an AI-powered multi-cluster Kubernetes dashboard (CNCF Sandbox project) that:
- Provides real-time observability and AI-guided operations across multiple clusters
- Integrates with 20+ CNCF projects: Argo, Kyverno, Prometheus, Grafana, Istio, Flux, Falco, OPA/Gatekeeper
- Complements configuration management tools by giving operators a live view of what is deployed

- **GitHub**: https://github.com/kubestellar/console
- **Demo**: https://console.kubestellar.io
- **CNCF Sandbox**: https://www.cncf.io/projects/kubestellar/