### PR TITLE
feat: add KubeStellar Console to Other Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ may be out of scope for this repository.
 | [chart-vendor](https://github.com/vexxhost/chart-vendor) | Vendor Helm charts; |
 | [helmfile/chartify](https://github.com/helmfile/chartify) | Generate Helm charts from Kubernetes manifests/Kustomization; |
 | [Karmada](https://github.com/karmada-io/karmada) | Multi-Cloud, Multi-Cluster Kubernetes Orchestration; |
+| [KubeStellar Console](https://github.com/kubestellar/console) | AI-powered multi-cluster Kubernetes management UI with Helm chart, MCP bridge, and GitOps integration; |
 | [Knative Serving](https://github.com/knative/serving) | Set of CRDs used to define serverless workloads; |
 | [koreo](https://github.com/koreo-dev/koreo-core) | Orchestrates multi-step processes that react to events and manage Kubernetes resources; |
 | [kro](https://github.com/kro-run/kro) | Define higher-level Kubernetes resources, composed of a multiple lower-level ones; |


### PR DESCRIPTION
KubeStellar Console is an open-source AI-powered UI for managing Kubernetes workloads across multiple clusters. It connects to clusters through your kubeconfig (via the local `kc-agent`), supports GitOps workflows, and ships a Helm chart for easy self-hosted deployment.

- **Repo**: https://github.com/kubestellar/console
- **License**: Apache-2.0
- **Multi-cluster**: yes, via KubeStellar / Karmada-compatible setup