### PR TITLE
Update Kapitan entry: add CUE input language

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ may be out of scope for this repository.
 | [k8skonf](https://github.com/konfjs/k8skonf) | GSL | TypeScript | |
 | [k8spkg](https://github.com/mgoltzsche/k8spkg) | MDL | | Abandoned; |
 | [kadet](https://github.com/kapicorp/kadet) | GL | Python | |
-| [Kapitan](https://github.com/kapicorp/kapitan) | GML | YAML, Jsonnet, Jinja2, Python | |
+| [Kapitan](https://github.com/kapicorp/kapitan) | GML | YAML, Jsonnet, Jinja2, Python, CUE | |
 | [kapp](https://github.com/carvel-dev/kapp) | DL | | |
 | [kapp-controller](https://github.com/carvel-dev/kapp-controller) | DI | | |
 | [karavel](https://github.com/gree-gorey/karavel) | GL | Python | |

--- a/config_tools.cue
+++ b/config_tools.cue
@@ -162,7 +162,7 @@ let _config_tools = [
 	{
 		name: {text: "Kapitan", repo: "kapicorp/kapitan"}
 		features: ["G", "M", "L"]
-		languages: ["YAML", "Jsonnet", "Jinja2", "Python"]
+		languages: ["YAML", "Jsonnet", "Jinja2", "Python", "CUE"]
 	},
 	{
 		name: {text: "kadet", repo: "kapicorp/kadet"}


### PR DESCRIPTION
The Kapitan row lists its input languages as YAML, Jsonnet, Jinja2, Python. Kapitan also supports CUE as an input type now, so this adds CUE.

I made the change in `config_tools.cue` and regenerated `README.md` with `cue cmd gen`, so the source and the generated table stay in sync.

- https://github.com/kapicorp/kapitan
